### PR TITLE
tests/test_Solver.py::test_AutoSearch3

### DIFF
--- a/flopt/solvers/auto_search.py
+++ b/flopt/solvers/auto_search.py
@@ -173,6 +173,9 @@ class AutoSearch(BaseSearch):
         except ModelNotFound as e:
             logger.warning(e)
             return BaseSelector()
+        except ValueError as e:
+            logger.warning(e)
+            return BaseSelector()
         return BaseSelector()
 
     def solve(self, solution, objective, constraints, prob, *args, **kwargs):


### PR DESCRIPTION
fix for

```
  /opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/sklearn/base.py:347: InconsistentVersionWarning: Trying to unpickle estimator DummyClassifier from version 1.1.2 when using version 1.3.0. This might lead to breaking code or invalid results. Use at your own risk. For more info please refer to:
   https://scikit-learn.org/stable/model_persistence.html#security-maintainability-limitations
     warnings.warn(
```